### PR TITLE
Backend/enhancement/implement swagger #289

### DIFF
--- a/app/backend/build.gradle.kts
+++ b/app/backend/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web:3.1.5")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.1.5")
 	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0")
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.0")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	runtimeOnly("org.postgresql:postgresql")
 	runtimeOnly("org.jetbrains.kotlin:kotlin-reflect:1.9.0")

--- a/app/backend/src/main/kotlin/com/gamelounge/backend/controller/AccessController.kt
+++ b/app/backend/src/main/kotlin/com/gamelounge/backend/controller/AccessController.kt
@@ -20,6 +20,7 @@ class AccessController(
     fun register(@RequestBody request: RegisterationRequest): ResponseEntity<Map<String, String>> {
         accessService.register(request)
         return ResponseEntity.status(HttpStatus.CREATED).body(mapOf("message" to "Registered successfully!"))
+    }
 
     @PostMapping("/login")
     fun login(@RequestBody request: LoginRequest): ResponseEntity<Pair<String, String>> {

--- a/app/backend/src/main/kotlin/com/gamelounge/backend/exception/CustomExceptions.kt
+++ b/app/backend/src/main/kotlin/com/gamelounge/backend/exception/CustomExceptions.kt
@@ -4,5 +4,4 @@ class UsernameNotFoundException(message: String) : RuntimeException(message)
 class WrongCredentialsException(message: String) : RuntimeException(message)
 class SessionNotFoundException(message: String) : RuntimeException(message)
 class LogoutFailedException(message: String) : RuntimeException(message)
-
 class UsernameAlreadyExistException(message: String): RuntimeException(message)

--- a/app/backend/src/main/kotlin/com/gamelounge/backend/exception/UsernameAlreadyExistException.kt
+++ b/app/backend/src/main/kotlin/com/gamelounge/backend/exception/UsernameAlreadyExistException.kt
@@ -1,4 +1,0 @@
-package com.gamelounge.backend.exception
-
-open class UsernameAlreadyExistException(message: String): RuntimeException(message) {
-}


### PR DESCRIPTION
The swagger is implemented and can be reached on local devices through "http://localhost:8080/swagger-ui/index.html". 

Since springfox had some problems with Spring Boot 3.x.x, openAPI's springdoc was used. The documentation for springdoc can be seen [here](https://springdoc.org/#properties).

---
![image](https://github.com/bounswe/bounswe2023group6/assets/74266381/9ab1ef88-c74b-4f3b-acda-2763d005c86f)

