### PR TITLE
[Mobile] user image null fix

### DIFF
--- a/app/mobile/lib/data/models/dto/user/user_response.dart
+++ b/app/mobile/lib/data/models/dto/user/user_response.dart
@@ -35,9 +35,10 @@ class UserDTOResponse extends BaseDTOObject<UserDTOResponse> {
         surname: json["surname"],
         email: json["email"],
         username: json["username"],
-        profileImage: ByteData.view(Uint8List.fromList(
-        base64Decode(json['image']),
-      ).buffer),
+        profileImage: json['image'] != null ? 
+          ByteData.view(Uint8List.fromList(
+            base64Decode(json['image']),
+          ).buffer) : null,
       );
 
   @override


### PR DESCRIPTION
While parsing user response; if image is null, null pointer exception occurs. I fixed this issue. 