### PR TITLE
[Mobile] Image annotation implementation

### DIFF
--- a/app/mobile/lib/presentation/pages/game_wiki_page.dart
+++ b/app/mobile/lib/presentation/pages/game_wiki_page.dart
@@ -5,6 +5,7 @@ import 'package:mobile/data/models/post_model.dart';
 import 'package:mobile/data/services/game_service.dart';
 import 'package:mobile/data/services/post_service.dart';
 import 'package:mobile/presentation/pages/game_page_create.dart';
+import 'package:mobile/presentation/widgets/annotatable_image_widget.dart';
 import 'package:mobile/presentation/widgets/app_bar_widget.dart';
 import 'package:mobile/presentation/widgets/drawer_widget.dart';
 import 'package:flutter_rating_bar/flutter_rating_bar.dart';
@@ -238,15 +239,7 @@ class _GameWikiPageState extends State<GameWikiPage>
                                   ),
                                 ],
                               )),
-                              Container(
-                                height: 200,
-                                width: 150, // Size of image
-                                decoration: BoxDecoration(
-                                    image: DecorationImage(
-                                  image: NetworkImage(game.gamePicture),
-                                  fit: BoxFit.fill,
-                                )),
-                              ),
+                              AnnotatableImageWidget(imageUrl: game.gamePicture),
                             ],
                           ),
                         ],

--- a/app/mobile/lib/presentation/widgets/annotatable_image_widget.dart
+++ b/app/mobile/lib/presentation/widgets/annotatable_image_widget.dart
@@ -1,0 +1,289 @@
+import 'dart:async';
+import 'dart:math';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+// import 'package:mobile/data/models/annotation_model.dart';
+import 'package:mobile/presentation/widgets/crop_image_widget.dart';
+
+class ImageAnnotation {
+  final double x;
+  final double y;
+  final double width;
+  final double height;
+  final String authorUsername;
+  final String annotation;
+
+  ImageAnnotation({
+    required this.x,
+    required this.y,
+    required this.width,
+    required this.height,
+    required this.authorUsername,
+    required this.annotation,
+  });
+}
+
+class AnnotatableImageWidget extends StatelessWidget {
+  final String imageUrl;
+  final double imageWidth = 200;
+  final double imageHeight = 200;
+
+  final List<ImageAnnotation> annotations = [
+    ImageAnnotation(
+      x: 10,
+      y: 10,
+      width: 100,
+      height: 50,
+      authorUsername: "user1",
+      annotation: "This is an annotation",
+    ),
+    ImageAnnotation(
+      x: 100,
+      y: 100,
+      width: 50,
+      height: 50,
+      authorUsername: "user2",
+      annotation: "This is another annotation",
+    ),
+    ImageAnnotation(
+      x: 30,
+      y: 30,
+      width: 50,
+      height: 50,
+      authorUsername: "user1",
+      annotation: "This is another annotation",
+    ),
+  ];
+
+  AnnotatableImageWidget({
+    Key? key,
+    required this.imageUrl,
+    // required this.annotations,
+  }) : super(key: key);
+
+  Future<ui.Image> getImageAsUi(NetworkImage image) async {
+    var completer = Completer<ImageInfo>();
+    image
+        .resolve(const ImageConfiguration())
+        .addListener(ImageStreamListener((info, _) {
+      completer.complete(info);
+    }));
+    ImageInfo imageInfo = await completer.future;
+    return imageInfo.image;
+  }
+
+  Offset convertPointToImageCoordinates(Offset point, ui.Image image) {
+    final widthRatio = image.width / imageWidth;
+    final heightRatio = image.height / imageHeight;
+
+    return Offset(
+      point.dx * widthRatio,
+      point.dy * heightRatio,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    NetworkImage image = NetworkImage(imageUrl);
+
+    return FutureBuilder(
+      future: getImageAsUi(image),
+      builder: (context, snapshot) {
+        switch (snapshot.connectionState) {
+          case ConnectionState.done:
+            return buildImageWithGestures(
+              context,
+              Column(
+                children: [
+                  Container(
+                    height: imageHeight,
+                    width: imageWidth,
+                    decoration: BoxDecoration(
+                        image: DecorationImage(
+                      image: image,
+                      fit: BoxFit.fill,
+                    )),
+                  ),
+                  annotations.isEmpty
+                      ? const Text(
+                          "No annotations",
+                          style: TextStyle(
+                            color: Colors.black,
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        )
+                      : TextButton(
+                          onPressed: () {
+                            showAnnotationsForImage(context, snapshot.data!);
+                          },
+                          child: const Text(
+                            "Show Annotations",
+                            style: TextStyle(
+                              color: Colors.black,
+                              fontSize: 16,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                ],
+              ),
+              snapshot.data!,
+            );
+          default:
+            return const Center(child: CircularProgressIndicator());
+        }
+      },
+    );
+  }
+
+  void showAnnotationsForImage(BuildContext context, ui.Image image) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text("Annotations for this image"),
+        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (final annotation in annotations)
+              Column(
+                children: [
+                  CustomPaint(
+                    painter: CropImageWidget(
+                      image: image,
+                      cropRect: Rect.fromLTWH(
+                        annotation.x,
+                        annotation.y,
+                        annotation.width,
+                        annotation.height,
+                      ),
+                    ),
+                    child: SizedBox(
+                      width: annotation.width,
+                      height: annotation.height,
+                    ),
+                  ),
+                  Text(annotation.annotation),
+                  Text(annotation.authorUsername),
+                ],
+              ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text("Close"),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget buildImageWithGestures(
+      BuildContext context, Widget imageWidget, ui.Image image) {
+    Offset localOffset = Offset.zero;
+    Offset topLeft = localOffset;
+    final bottomRight = ValueNotifier<Offset>(Offset.zero);
+
+    return GestureDetector(
+      child: Stack(
+        children: [
+          imageWidget,
+          ValueListenableBuilder(
+            valueListenable: bottomRight,
+            builder: (context, bottomRight, child) => bottomRight == Offset.zero
+                ? Container()
+                : Positioned(
+                    left: min(topLeft.dx, bottomRight.dx),
+                    top: min(topLeft.dy, bottomRight.dy),
+                    child: Container(
+                      width: (bottomRight.dx - topLeft.dx).abs(),
+                      height: (bottomRight.dy - topLeft.dy).abs(),
+                      decoration: BoxDecoration(
+                        border: Border.all(
+                          color: Colors.black87,
+                          width: 1,
+                        ),
+                      ),
+                    ),
+                  ),
+          )
+        ],
+      ),
+      onLongPressStart: (details) {
+        localOffset = details.localPosition;
+        topLeft = localOffset;
+        bottomRight.value = localOffset;
+      },
+      onLongPressMoveUpdate: (details) {
+        localOffset = details.localPosition;
+        bottomRight.value = localOffset;
+      },
+      onLongPressEnd: (details) {
+        topLeft = convertPointToImageCoordinates(topLeft, image);
+        Offset bottomRightOffset =
+            convertPointToImageCoordinates(bottomRight.value, image);
+        showDialog(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: const Text("Make an annotation"),
+            contentPadding:
+                const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                CustomPaint(
+                  painter: CropImageWidget(
+                    image: image,
+                    cropRect: Rect.fromPoints(
+                      topLeft,
+                      bottomRightOffset,
+                    ),
+                  ),
+                  child: SizedBox(
+                    width: (bottomRightOffset.dx - topLeft.dx).abs(),
+                    height: (bottomRightOffset.dy - topLeft.dy).abs(),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                TextFormField(
+                  key: GlobalObjectKey(UniqueKey()),
+                  keyboardType: TextInputType.multiline,
+                  maxLength: 500,
+                  decoration: const InputDecoration(
+                      border: OutlineInputBorder(),
+                      hintText: "Enter your annotation here"),
+                  maxLines: 8,
+                ),
+              ],
+            ),
+            actions: [
+              TextButton(
+                onPressed: () {
+                  // TODO: Save annotation
+                  Navigator.of(context).pop("Annotation saved");
+                },
+                child: const Text("Save Annotation"),
+              ),
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text("Cancel"),
+              ),
+            ],
+          ),
+        ).then((value) {
+          bottomRight.value = Offset.zero;
+          if (value != null) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(value.toString()),
+              ),
+            );
+          }
+        });
+      },
+    );
+  }
+}

--- a/app/mobile/lib/presentation/widgets/crop_image_widget.dart
+++ b/app/mobile/lib/presentation/widgets/crop_image_widget.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/painting.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'dart:ui' as ui;
+
+class CropImageWidget extends CustomPainter {
+  final ui.Image image;
+  final Rect cropRect;
+  CropImageWidget({required this.image, required this.cropRect});
+  
+  @override
+  void paint(Canvas canvas, Size size) {
+    canvas.drawAtlas(
+        image,
+        [
+          /* Identity transform */
+          RSTransform.fromComponents(
+              rotation: 0.0,
+              scale: 1.0,
+              anchorX: 0.0,
+              anchorY: 0.0,
+              translateX: 0.0,
+              translateY: 0.0)
+        ],
+        [
+            Rect.fromLTWH(cropRect.left, cropRect.top, cropRect.width, cropRect.height)
+        ],
+        [/* No need for colors */],
+        BlendMode.src,
+        null /* No need for cullRect */,
+        Paint());
+  }
+
+  @override
+  bool shouldRepaint(CropImageWidget oldDelegate) => false;
+  @override
+  bool shouldRebuildSemantics(CropImageWidget oldDelegate) => false;
+}


### PR DESCRIPTION
Following changes are made:
- Crop image widget added
- Annotatable image widget added

Annotatable image can be tested on game page picture. 
To annotate an image, long press on the image and create a rectangle. When you release the press, a pop-up should be shown and you can create annotation from this pop-up. 

Since backend side is not ready yet, backend connections are not made. 